### PR TITLE
Fix 16KB roms not decompiling

### DIFF
--- a/NESDecompiler.Core/Disassembly/Disassembler.cs
+++ b/NESDecompiler.Core/Disassembly/Disassembler.cs
@@ -230,7 +230,8 @@ namespace NESDecompiler.Core.Disassembly
         {
             try
             {
-                ushort baseAddress = 0x8000;
+                // ushort baseAddress = 0x8000;
+                ushort baseAddress = (ushort)(0x10000 - romInfo.PRGROMSize);
 
                 while (offset < codeData.Length)
                 {


### PR DESCRIPTION
Roms with only 16KB of program code had the incorrect base address during the disassembly process. This caused the instructions not to be found.

Fixed by making sure the base address is adjusted based on the prgRomData size.