### PR TITLE
Loopback jumps should occur on the same cpu address of the jump

### DIFF
--- a/NESDecompiler.Core/Decompilation/FunctionDecompiler.cs
+++ b/NESDecompiler.Core/Decompilation/FunctionDecompiler.cs
@@ -26,7 +26,7 @@ public static class FunctionDecompiler
                     // This means a branch occurred that caused the flow to wrap around to instructions preceding
                     // the function entrance. This usually happens when there is a jump/branch to right before the
                     // entrypoint, usually due to decompiling in the middle of a loop. To fix this, we need to add
-                    // a jump back to the function entrypoint
+                    // a jump back to the function entrypoint.
                     if (functionAddress == 0x00)
                     {
                         const string message = "Wrap around instruction detected for a function at 0000, but that " +
@@ -41,12 +41,12 @@ public static class FunctionDecompiler
                     var jumpInstruction = new DisassembledInstruction
                     {
                         Info = InstructionSet.GetInstruction(0x4C),
-                        CPUAddress = (ushort)(nextAddress - 1),
+                        CPUAddress = nextAddress,
                         Bytes = [0x4C, (byte)addressLow, (byte)addressHigh],
                         TargetAddress = functionAddress,
 
-                        // Make sure they appear after any instruction that already occupies that address
-                        SubAddressOrder = 1,
+                        // Make sure they appear before the function address
+                        SubAddressOrder = -1,
                     };
 
                     instructions.Add(jumpInstruction);
@@ -92,7 +92,8 @@ public static class FunctionDecompiler
         // Add labels for any jump targets
         foreach (var instruction in instructions)
         {
-            if (jumpAddresses.Contains(instruction.CPUAddress))
+            // Only real instructions should have a label, virtual ones should not
+            if (jumpAddresses.Contains(instruction.CPUAddress) && instruction.SubAddressOrder == 0)
             {
                 instruction.Label = $"loc_{instruction.CPUAddress:X4}";
             }

--- a/NESDecompiler.Core/Disassembly/Disassembler.cs
+++ b/NESDecompiler.Core/Disassembly/Disassembler.cs
@@ -78,7 +78,7 @@ namespace NESDecompiler.Core.Disassembly
         /// address location at runtime. Can be used to add runtime hooks or to work around
         /// decompilation issues. Should be 0 for all native instructions from a ROM.
         /// </summary>
-        public byte SubAddressOrder { get; set; }
+        public sbyte SubAddressOrder { get; set; }
 
         /// <summary>
         /// Returns a string representation of this instruction


### PR DESCRIPTION
When a function is decompiled in the middle of a function, and that function has a jump point prior to the function's entry point, we need to add a fake virtual instruction that jumps back to the start of the function.

The virtual instruction needs to be the last instruction in the ordered instruction set.

We previously accomplished that by adding an instruction at the location of the function entrypiont minus one. However, this was failing in cases where a system would cause an interrupt right on the virtual address. Emulators would then save the virtual instruction's address to the stack, and jump back into that address once RTI occurs.

This fails because the virtual address can't be decompiled, because legit code doesn't exist at that address.

To fix this, I updated the `SubAddressOrder` property to allow for negative values. This allows the loopback instruction to be on the correct CPUAddress while still being ordered as expected.

Also ensured that virtual addresses do not get labels, as they are not actually valid jump targets.